### PR TITLE
added missing npm dev dependency

### DIFF
--- a/bowling-game/package.json
+++ b/bowling-game/package.json
@@ -3,6 +3,7 @@
     "gulp": "^3.8.7",
     "gulp-notify": "^1.5.0",
     "gulp-phpspec": "^0.2.5",
+    "gulp-plumber": "^1.1.0",
     "gulp-run": "^1.6.4"
   }
 }

--- a/prime-factors/package.json
+++ b/prime-factors/package.json
@@ -3,6 +3,7 @@
     "gulp": "^3.8.7",
     "gulp-notify": "^1.5.0",
     "gulp-phpspec": "^0.2.5",
+    "gulp-plumber": "^1.1.0",
     "gulp-run": "^1.6.4"
   }
 }

--- a/roman-numerals/package.json
+++ b/roman-numerals/package.json
@@ -3,6 +3,7 @@
     "gulp": "^3.8.7",
     "gulp-notify": "^1.5.0",
     "gulp-phpspec": "^0.2.5",
+    "gulp-plumber": "^1.1.0",
     "gulp-run": "^1.6.4"
   }
 }

--- a/string-calculator/package.json
+++ b/string-calculator/package.json
@@ -3,6 +3,7 @@
     "gulp": "^3.8.7",
     "gulp-notify": "^1.5.0",
     "gulp-phpspec": "^0.2.5",
+    "gulp-plumber": "^1.1.0",
     "gulp-run": "^1.6.4"
   }
 }

--- a/tennis-match/package.json
+++ b/tennis-match/package.json
@@ -3,6 +3,7 @@
         "gulp": "^3.8.7",
         "gulp-notify": "^1.5.0",
         "gulp-phpspec": "^0.2.5",
+	    "gulp-plumber": "^1.1.0",
         "gulp-run": "^1.6.4"
     }
 }


### PR DESCRIPTION
added missing dev dependency (gulp-plumber) to allow user to run gulp without an error.

Without this:

```
$ gulp
Warning: gulp-run is deprecated
module.js:338
    throw err;
          ^
Error: Cannot find module 'gulp-plumber'
```
